### PR TITLE
fix missing div start tag for unknown media files

### DIFF
--- a/inc_print_image_thumb.php
+++ b/inc_print_image_thumb.php
@@ -77,6 +77,7 @@
 					} else { ?>
 					<a class="thumb" href="<?php echo html_encode(pathurlencode($fullimage)); ?>" title="<?php echo html_encode(getBareImageTitle()); ?>">
 						<?php printImageThumb(getBareImageTitle(), 'remove-attributes img-responsive'); ?>
+						<div class="hidden caption">
 							<h4><?php printBareImageTitle(); ?></h4>
 							<?php echo printImageDesc(); ?>
 						</div>


### PR DESCRIPTION
fix missing div start tag for unknown media files that made extra title and description visible in album.

"unknown" media breaks thumbnail grid in an album by showing an extra instance of the item name and description. Looks like this is just a missing <div class="hidden caption"> start tag in inc_print_image_thumb.php